### PR TITLE
static calls without JS callback

### DIFF
--- a/TestEnvironment/demo-static-parent-issue/MyClass.php
+++ b/TestEnvironment/demo-static-parent-issue/MyClass.php
@@ -11,11 +11,28 @@ class MyClass extends ParentClass
 		$refreshedEntity->entityMethod(); // auto-complete does not work for this
 	}
 
+	public function loadWithoutCallback()
+	{
+		$dataProvider = DataProviderWithStaticFactory::getDataProvider();
+		$entity = $dataProvider->returnData();
+
+		$refreshedEntity = self::refreshEntityWithoutCallback($entity);
+		$refreshedEntity->entityMethod(); // auto-complete does not work for this
+	}
+
 	public function loadStaticProperty()
 	{
 		$user = StaticPropertyDataProvider::$user->getAccessToken();
 
 		$refreshedAccessToken = self::refreshEntity($user);
+		$refreshedAccessToken->isValid(); // auto-complete does not work for this
+	}
+
+	public function loadStaticPropertyWithoutCallback()
+	{
+		$user = StaticPropertyDataProvider::$user->getAccessToken();
+
+		$refreshedAccessToken = self::refreshEntityWithoutCallback($user);
 		$refreshedAccessToken->isValid(); // auto-complete does not work for this
 	}
 }

--- a/TestEnvironment/demo-static-parent-issue/ParentClass.php
+++ b/TestEnvironment/demo-static-parent-issue/ParentClass.php
@@ -10,4 +10,13 @@ class ParentClass
 	{
 		return $entity;
 	}
+
+	/**
+	* @param object $entity
+	* @return object
+	*/
+	public static function refreshEntityWithoutCallback($entity)
+	{
+		return $entity;
+	}
 }

--- a/TestEnvironment/demo-static-parent-issue/dynamicReturnTypeMeta.json
+++ b/TestEnvironment/demo-static-parent-issue/dynamicReturnTypeMeta.json
@@ -5,6 +5,11 @@
       "method": "refreshEntity",
       "position": 0,
       "fileReturnTypeReplacementCall": ["Callbacks.js", "info"]
+    },
+    {
+      "class": "\\ParentClass",
+      "method": "refreshEntityWithoutCallback",
+      "position": 0
     }
   ]
 }


### PR DESCRIPTION
@pbyrne84 Hello, it's me again :wink: 

I found another edge-case. When I want to use simple class name resolving without JS callbacks (should be faster, right?), it does not work in these cases. (it works fine with the callbacks thanks to the recent fixes)
