### PR TITLE
autocomplete does not work for static property used as a parameter

### DIFF
--- a/TestEnvironment/demo-static-parent-issue/MyClass.php
+++ b/TestEnvironment/demo-static-parent-issue/MyClass.php
@@ -35,6 +35,24 @@ class MyClass extends ParentClass
 		$refreshedAccessToken = self::refreshEntityWithoutCallback($user);
 		$refreshedAccessToken->isValid(); // auto-complete does not work for this
 	}
+
+	public function loadStaticPropertyDirectly()
+	{
+		$refreshedToken = self::refreshEntity(StaticPropertyDataProvider::$user->getAccessToken());
+		$refreshedToken->isValid(); // works fine
+
+		$refreshedUser = self::refreshEntity(StaticPropertyDataProvider::$user);
+		$refreshedUser->getAccessToken(); // auto-complete does not work for this
+	}
+
+	public function loadStaticPropertyDirectlyWithoutCallback()
+	{
+		$refreshedToken = self::refreshEntityWithoutCallback(StaticPropertyDataProvider::$user->getAccessToken());
+		$refreshedToken->isValid(); // works fine
+
+		$refreshedUser = self::refreshEntityWithoutCallback(StaticPropertyDataProvider::$user);
+		$refreshedUser->getAccessToken(); // auto-complete does not work for this
+	}
 }
 
 class FooEntity


### PR DESCRIPTION
Hello @pbyrne84!

I've discovered another edge - when the static property is passed directly to the method, resolving doesn't work properly (it works fine if I call a method on the property first).
