### PR TITLE
autocomplete doesn't work when the plugin processes the value twice

### DIFF
--- a/TestEnvironment/demo/demo.php
+++ b/TestEnvironment/demo/demo.php
@@ -27,6 +27,22 @@ class Processor
 		$out->boo(); // does not work unless I copy the DataProvider class into this file
 	}
 
+	/**
+	 * @param \FooX[] $data
+	 */
+	public function processTwice(array $data)
+	{
+		$filteredData = Arr::filterArray($data, function (FooX $fooValue) {
+			return true;
+		});
+		$filteredData[0]->boo(); // works fine
+
+		$oneValue = Arr::getValueByCallback($filteredData, function (FooX $fooValue) {
+			return true;
+		});
+
+		$oneValue->boo(); // autocompletion does not work
+	}
 }
 
 class Arr
@@ -34,5 +50,19 @@ class Arr
 	public static function getFirst(array $a)
 	{
 		return $a[0];
+	}
+
+	public static function filterArray(array $a, callable $callback)
+	{
+		return array_filter($a, $callback);
+	}
+
+	public static function getValueByCallback(array $a, callable $callback)
+	{
+		foreach ($a as $item) {
+			if ($callback($item) === true) {
+				return $item;
+			}
+		}
 	}
 }

--- a/TestEnvironment/demo/dynamicReturnTypeMeta.json
+++ b/TestEnvironment/demo/dynamicReturnTypeMeta.json
@@ -5,6 +5,17 @@
       "method": "getFirst",
       "position": 0,
       "fileReturnTypeReplacementCall": ["ArrayCallbacks.js", "arrayToSingleInstance"]
+    },
+    {
+      "class": "\\Arr",
+      "method": "getValueByCallback",
+      "position": 0,
+      "fileReturnTypeReplacementCall": ["ArrayCallbacks.js", "arrayToSingleInstance"]
+    },
+    {
+      "class": "\\Arr",
+      "method": "filterArray",
+      "position": 0
     }
   ]
 }


### PR DESCRIPTION
@pbyrne84 this issue is probably unrelated to the previous one.

We are using own wrappers of the array operations and when we use it twice (in this case: filtering and then searching for a value), autocompletion does not work (it works fine for each case separately).
